### PR TITLE
Fix: hidden navbar toggler button

### DIFF
--- a/mkdocs_dracula_theme/modules/header.html
+++ b/mkdocs_dracula_theme/modules/header.html
@@ -1,14 +1,14 @@
 <header>
     <nav class="navbar navbar-expand-xl drac-bg-purple"">
         <div class="container-fluid">
-
-            <!-- <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsMenu"
+            
+            <button class="navbar-toggler w-100 text-center" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsMenu"
                 aria-controls="navbarsMenu" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
-            </button> -->
+            </button>
 
             <div class="collapse navbar-collapse flex-column ml-auto" id="navbarsMenu">
-                <ul class="navbar-nav">
+                <ul class="navbar-nav text-md-center">
 
                     <!-- block preview -->
                     <li class="nav-item">


### PR DESCRIPTION
Hello, excellent theme for documents, thank you.

I found a problem with a low resolution screen, you lose the navigation bar.

**Change:** Fix: Uncomment navigation bar toggle button and center content

## Screenshot

![2024-01-08_22-30](https://github.com/dracula/mkdocs/assets/10056152/f6d60e1e-0cb9-4134-b180-62d9658c9bbb)
