### PR TITLE
feat: add show_footer config option to hide footer

### DIFF
--- a/mkdocs_dracula_theme/base.html
+++ b/mkdocs_dracula_theme/base.html
@@ -84,7 +84,9 @@
 
             <!-- block footer -->
             {%- block footer %}
-                {% include "/modules/footer.html" %}
+                {% if config.theme.show_footer %}
+                    {% include "/modules/footer.html" %}
+                {% endif %}
             {%- endblock %}
             <!-- endblock -->
         </div>

--- a/mkdocs_dracula_theme/mkdocs_theme.yml
+++ b/mkdocs_dracula_theme/mkdocs_theme.yml
@@ -8,3 +8,5 @@ search_index_only: false
 
 highlightjs: true
 hljs_languages: []
+
+show_footer: true


### PR DESCRIPTION
## Description

- `mkdocs_dracula_theme/mkdocs_theme.yml`: added `show_footer: true` as a default config key
- `mkdocs_dracula_theme/base.html`: wrapped the footer include block with `{% if config.theme.show_footer %}` conditional

## Motivation and Context

Users who want to hide the "Made with Dracula Theme for MkDocs" footer had no native way to do so. Setting `show_footer: false` in `mkdocs.yml` now suppresses it cleanly without requiring a `custom_dir` override.

Closes #28

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG
- [ ] I have updated the documentation accordingly